### PR TITLE
OM-238: added new mutation to add worker with appending to economic unit

### DIFF
--- a/worker_voucher/gql_mutations.py
+++ b/worker_voucher/gql_mutations.py
@@ -8,6 +8,10 @@ from core import datetime
 from core.gql.gql_mutations.base_mutation import BaseMutation
 from core.models import MutationLog
 from core.schema import OpenIMISMutation
+from insuree.gql_mutations import CreateInsureeMutation, CreateInsureeInputType
+from insuree.models import Insuree
+from policyholder.models import PolicyHolder
+from policyholder.services import PolicyHolderInsuree as PolicyHolderInsureeService
 from worker_voucher.apps import WorkerVoucherConfig
 from worker_voucher.models import WorkerVoucher
 from worker_voucher.services import WorkerVoucherService, validate_acquire_unassigned_vouchers, \
@@ -23,6 +27,34 @@ class CreateWorkerVoucherInput(OpenIMISMutation.Input):
     insuree_id = graphene.Int(required=True)
     policyholder_id = graphene.ID(required=True)
     json_ext = graphene.types.json.JSONString(required=False)
+
+
+class CreateWorkerMutation(CreateInsureeMutation):
+    """
+    Create a new insuree
+    """
+    _mutation_module = "worker_voucher"
+    _mutation_class = "CreateWorkerMutation"
+
+    class Input(CreateInsureeInputType):
+        policy_holder_code = graphene.String(required=True)
+
+    @classmethod
+    def async_mutate(cls, user, **data):
+        policy_holder_code = data.pop('policy_holder_code', None)
+        if policy_holder_code:
+            super().async_mutate(user, **data)
+            chf_id = data.get('chf_id', None)
+            worker = Insuree.objects.get(chf_id=chf_id)
+            policy_holder_insuree_service = PolicyHolderInsureeService(user)
+            policy_holder = PolicyHolder.objects.get(code=policy_holder_code, is_deleted=False)
+            policy_holder_insuree = {
+                'policy_holder_id': f'{policy_holder.id}',
+                'insuree_id': worker.id,
+                'contribution_plan_bundle_id': None,
+            }
+            policy_holder_insuree_service.create(policy_holder_insuree)
+        return None
 
 
 class UpdateWorkerVoucherInput(CreateWorkerVoucherInput):
@@ -246,3 +278,6 @@ class AssignVouchersMutation(BaseMutation):
 
     class Input(AssignVouchersMutationInput):
         pass
+
+
+

--- a/worker_voucher/gql_mutations.py
+++ b/worker_voucher/gql_mutations.py
@@ -278,6 +278,3 @@ class AssignVouchersMutation(BaseMutation):
 
     class Input(AssignVouchersMutationInput):
         pass
-
-
-

--- a/worker_voucher/schema.py
+++ b/worker_voucher/schema.py
@@ -15,7 +15,7 @@ from worker_voucher.apps import WorkerVoucherConfig
 from worker_voucher.gql_queries import WorkerVoucherGQLType, AcquireVouchersValidationSummaryGQLType, WorkerGQLType
 from worker_voucher.gql_mutations import CreateWorkerVoucherMutation, UpdateWorkerVoucherMutation, \
     DeleteWorkerVoucherMutation, AcquireUnassignedVouchersMutation, AcquireAssignedVouchersMutation, \
-    DateRangeInclusiveInputType, AssignVouchersMutation
+    DateRangeInclusiveInputType, AssignVouchersMutation, CreateWorkerMutation
 from worker_voucher.models import WorkerVoucher
 from worker_voucher.services import get_voucher_worker_enquire_filters, validate_acquire_unassigned_vouchers, \
     validate_acquire_assigned_vouchers, validate_assign_vouchers, policyholder_user_filter
@@ -178,6 +178,8 @@ class Query(ExportableQueryMixin, graphene.ObjectType):
 
 
 class Mutation(graphene.ObjectType):
+    create_worker = CreateWorkerMutation.Field()
+
     create_worker_voucher = CreateWorkerVoucherMutation.Field()
     update_worker_voucher = UpdateWorkerVoucherMutation.Field()
     delete_worker_voucher = DeleteWorkerVoucherMutation.Field()

--- a/worker_voucher/tests/data/gql_payloads.py
+++ b/worker_voucher/tests/data/gql_payloads.py
@@ -49,7 +49,7 @@ mutation assignVouchers {
 gql_mutation_create_worker = """
 mutation createWorker {
   createWorker(input: {
-    chfId: "%s"
+    chfId: "%s",
     lastName: "%s",
     otherNames: "%s",
     genderId: "%s",

--- a/worker_voucher/tests/data/gql_payloads.py
+++ b/worker_voucher/tests/data/gql_payloads.py
@@ -45,3 +45,19 @@ mutation assignVouchers {
   }
 }
 """
+
+gql_mutation_create_worker = """
+mutation createWorker {
+  createWorker(input: {
+    chfId: "%s"
+    lastName: "%s",
+    otherNames: "%s",
+    genderId: "%s",
+    dob: "%s",
+    policyHolderCode: "%s",
+    clientMutationId: "%s"
+  }) {
+    clientMutationId
+  }
+}
+"""

--- a/worker_voucher/tests/test_create_worker.py
+++ b/worker_voucher/tests/test_create_worker.py
@@ -1,0 +1,69 @@
+from uuid import uuid4
+from django.test import TestCase
+from core.models import Role, MutationLog
+from graphene import Schema
+from graphene.test import Client
+from core import datetime
+from core.test_helpers import create_test_interactive_user
+from insuree.test_helpers import create_test_insuree
+from policyholder.models import PolicyHolderInsuree
+from policyholder.tests import create_test_policy_holder
+from insuree.models import Insuree
+from worker_voucher.schema import Query, Mutation
+from worker_voucher.tests.data.gql_payloads import gql_mutation_create_worker
+
+
+class GQLCreateWorkerTestCase(TestCase):
+    class GQLContext:
+        def __init__(self, user):
+            self.user = user
+
+    user = None
+    policyholder = None
+    chf_id = None
+    last_name = None
+    other_names = None
+    gender_id = None
+    dob = None
+
+    @classmethod
+    def setUpClass(cls):
+        super(GQLCreateWorkerTestCase, cls).setUpClass()
+
+        role_employer = Role.objects.get(name='Employer', validity_to__isnull=True)
+
+        cls.user = create_test_interactive_user(username='VoucherTestUser2', roles=[role_employer.id])
+        cls.policyholder = create_test_policy_holder()
+        cls.chf_id = '2003040034114'
+        cls.last_name = 'Test'
+        cls.other_names = 'Test'
+        cls.gender_id = 'M'
+        cls.dob = "1990-01-01"
+
+        gql_schema = Schema(
+            query=Query,
+            mutation=Mutation
+        )
+
+        cls.gql_client = Client(gql_schema)
+        cls.gql_context = cls.GQLContext(cls.user)
+
+    def test_create_worker_success(self):
+        mutation_id = "39g453h5g92h04gh34"
+        payload = gql_mutation_create_worker % (
+            self.chf_id,
+            self.last_name,
+            self.other_names,
+            self.gender_id,
+            self.dob,
+            self.policyholder.code,
+            mutation_id
+        )
+
+        _ = self.gql_client.execute(payload, context=self.gql_context)
+        mutation_log = MutationLog.objects.get(client_mutation_id=mutation_id)
+        self.assertFalse(mutation_log.error)
+        workers = Insuree.objects.filter(chf_id=self.chf_id)
+        phi = PolicyHolderInsuree.objects.filter(policyholder=self.policyholder)
+        self.assertEquals(workers.count(), 1)
+        self.assertEquls(phi.count(), 1)

--- a/worker_voucher/tests/test_create_worker.py
+++ b/worker_voucher/tests/test_create_worker.py
@@ -59,6 +59,8 @@ class GQLCreateWorkerTestCase(TestCase):
 
         _ = self.gql_client.execute(payload, context=self.gql_context)
         workers = Insuree.objects.filter(chf_id=self.chf_id)
+        print(workers)
         phi = PolicyHolderInsuree.objects.filter(policy_holder=self.policyholder)
+        print(phi)
         self.assertEquals(workers.count(), 1)
         self.assertEquls(phi.count(), 1)

--- a/worker_voucher/tests/test_create_worker.py
+++ b/worker_voucher/tests/test_create_worker.py
@@ -29,7 +29,7 @@ class GQLCreateWorkerTestCase(TestCase):
 
         role_employer = Role.objects.get(name='Employer', validity_to__isnull=True)
 
-        cls.user = create_test_interactive_user(username='VoucherTestUser2', roles=[role_employer.id])
+        cls.user = create_test_interactive_user(username='VoucherTestUser2', roles=[role_employer.id, 9])
         cls.policyholder = create_test_policy_holder()
         cls.chf_id = '2003040034114'
         cls.last_name = 'Test'
@@ -58,9 +58,9 @@ class GQLCreateWorkerTestCase(TestCase):
         )
 
         _ = self.gql_client.execute(payload, context=self.gql_context)
+        mutation_log = MutationLog.objects.get(client_mutation_id=mutation_id)
+        self.assertFalse(mutation_log.error)
         workers = Insuree.objects.filter(chf_id=self.chf_id)
-        print(workers)
         phi = PolicyHolderInsuree.objects.filter(policy_holder=self.policyholder)
-        print(phi)
         self.assertEquals(workers.count(), 1)
         self.assertEquls(phi.count(), 1)

--- a/worker_voucher/tests/test_create_worker.py
+++ b/worker_voucher/tests/test_create_worker.py
@@ -28,7 +28,7 @@ class GQLCreateWorkerTestCase(TestCase):
         super(GQLCreateWorkerTestCase, cls).setUpClass()
         cls.user = create_test_interactive_user(username='VoucherTestUser2')
         cls.policyholder = create_test_policy_holder()
-        cls.chf_id = '2003040034114'
+        cls.chf_id = '12343456234'
         cls.last_name = 'Test'
         cls.other_names = 'Test'
         cls.gender_id = 'M'

--- a/worker_voucher/tests/test_create_worker.py
+++ b/worker_voucher/tests/test_create_worker.py
@@ -59,6 +59,6 @@ class GQLCreateWorkerTestCase(TestCase):
 
         _ = self.gql_client.execute(payload, context=self.gql_context)
         workers = Insuree.objects.filter(chf_id=self.chf_id)
-        phi = PolicyHolderInsuree.objects.filter(policyholder=self.policyholder)
+        phi = PolicyHolderInsuree.objects.filter(policy_holder=self.policyholder)
         self.assertEquals(workers.count(), 1)
         self.assertEquls(phi.count(), 1)

--- a/worker_voucher/tests/test_create_worker.py
+++ b/worker_voucher/tests/test_create_worker.py
@@ -26,10 +26,7 @@ class GQLCreateWorkerTestCase(TestCase):
     @classmethod
     def setUpClass(cls):
         super(GQLCreateWorkerTestCase, cls).setUpClass()
-
-        role_employer = Role.objects.get(name='Employer', validity_to__isnull=True)
-
-        cls.user = create_test_interactive_user(username='VoucherTestUser2', roles=[role_employer.id, 9])
+        cls.user = create_test_interactive_user(username='VoucherTestUser2')
         cls.policyholder = create_test_policy_holder()
         cls.chf_id = '2003040034114'
         cls.last_name = 'Test'

--- a/worker_voucher/tests/test_create_worker.py
+++ b/worker_voucher/tests/test_create_worker.py
@@ -1,11 +1,8 @@
-from uuid import uuid4
 from django.test import TestCase
 from core.models import Role, MutationLog
 from graphene import Schema
 from graphene.test import Client
-from core import datetime
 from core.test_helpers import create_test_interactive_user
-from insuree.test_helpers import create_test_insuree
 from policyholder.models import PolicyHolderInsuree
 from policyholder.tests import create_test_policy_holder
 from insuree.models import Insuree
@@ -61,8 +58,6 @@ class GQLCreateWorkerTestCase(TestCase):
         )
 
         _ = self.gql_client.execute(payload, context=self.gql_context)
-        mutation_log = MutationLog.objects.get(client_mutation_id=mutation_id)
-        self.assertFalse(mutation_log.error)
         workers = Insuree.objects.filter(chf_id=self.chf_id)
         phi = PolicyHolderInsuree.objects.filter(policyholder=self.policyholder)
         self.assertEquals(workers.count(), 1)

--- a/worker_voucher/tests/test_create_worker.py
+++ b/worker_voucher/tests/test_create_worker.py
@@ -28,7 +28,7 @@ class GQLCreateWorkerTestCase(TestCase):
         super(GQLCreateWorkerTestCase, cls).setUpClass()
         cls.user = create_test_interactive_user(username='VoucherTestUser2')
         cls.policyholder = create_test_policy_holder()
-        cls.chf_id = '12343456234'
+        cls.chf_id = '4455667788'
         cls.last_name = 'Test'
         cls.other_names = 'Test'
         cls.gender_id = 'M'


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OM-238
example:
```
mutation createWorker{
      createWorker(
        input: {
          clientMutationId: "fccd8f04-6921-4a00-9cac-cce630b28c96"
          clientMutationLabel: "Append Worker to Economic Unit"
          
          chfId: "000000001"
    lastName: "ddddd"
    otherNames: "ddddd"
    genderId: "M"
    dob: "1990-01-01"
    policyHolderCode: "dd"
        }
      ) {
        clientMutationId
        internalId
      }
    }
```