### PR TITLE
OM-359: changed validation errors messages to key messages

### DIFF
--- a/worker_voucher/gql_mutations.py
+++ b/worker_voucher/gql_mutations.py
@@ -340,8 +340,14 @@ class AcquireAssignedVouchersMutation(BaseMutation):
 
         validate_result = validate_acquire_assigned_vouchers(user, economic_unit_code, workers, date_ranges)
         if not validate_result.get("success", False):
-            return validate_result
+            error_message = validate_result["error"]["message"]
+            error_extensions = validate_result["error"].get("extensions", {})
 
+            return GraphQLError(
+                message=error_message,
+                extensions=error_extensions
+            )
+        
         policyholder_id = validate_result.get("data").get("policyholder").id
         voucher_ids = []
         with transaction.atomic():
@@ -390,9 +396,15 @@ class AssignVouchersMutation(BaseMutation):
         data.pop('client_mutation_label', None)
 
         validate_result = validate_assign_vouchers(user, economic_unit_code, workers, date_ranges)
-        if not validate_result.get("success", False):
-            return validate_result
 
+        if not validate_result.get("success", False):
+            error_message = validate_result["error"]["message"]
+            error_extensions = validate_result["error"].get("extensions", {})
+
+            return GraphQLError(
+                message=error_message,
+                extensions=error_extensions
+            )
         voucher_ids = []
         vouchers = validate_result.get("data").get("unassigned_vouchers")
         with transaction.atomic():

--- a/worker_voucher/gql_mutations.py
+++ b/worker_voucher/gql_mutations.py
@@ -8,7 +8,7 @@ from core import datetime
 from core.gql.gql_mutations.base_mutation import BaseMutation
 from core.models import MutationLog
 from core.schema import OpenIMISMutation
-from graphql import GraphQLError
+
 from insuree.apps import InsureeConfig
 from insuree.gql_mutations import CreateInsureeMutation, CreateInsureeInputType
 from insuree.models import Insuree
@@ -275,13 +275,7 @@ class AcquireUnassignedVouchersMutation(BaseMutation):
 
         validate_result = validate_acquire_unassigned_vouchers(user, economic_unit_code, count)
         if not validate_result.get("success", False):
-            error_message = validate_result["error"]["message"]
-            error_extensions = validate_result["error"].get("extensions", {})
-
-            return GraphQLError(
-                message=error_message,
-                extensions=error_extensions
-            )
+            return validate_result
 
         policyholder_id = validate_result.get("data").get("policyholder").id
         voucher_ids = []
@@ -340,14 +334,8 @@ class AcquireAssignedVouchersMutation(BaseMutation):
 
         validate_result = validate_acquire_assigned_vouchers(user, economic_unit_code, workers, date_ranges)
         if not validate_result.get("success", False):
-            error_message = validate_result["error"]["message"]
-            error_extensions = validate_result["error"].get("extensions", {})
+            return validate_result
 
-            return GraphQLError(
-                message=error_message,
-                extensions=error_extensions
-            )
-        
         policyholder_id = validate_result.get("data").get("policyholder").id
         voucher_ids = []
         with transaction.atomic():
@@ -398,13 +386,7 @@ class AssignVouchersMutation(BaseMutation):
         validate_result = validate_assign_vouchers(user, economic_unit_code, workers, date_ranges)
 
         if not validate_result.get("success", False):
-            error_message = validate_result["error"]["message"]
-            error_extensions = validate_result["error"].get("extensions", {})
-
-            return GraphQLError(
-                message=error_message,
-                extensions=error_extensions
-            )
+            return validate_result
         voucher_ids = []
         vouchers = validate_result.get("data").get("unassigned_vouchers")
         with transaction.atomic():

--- a/worker_voucher/gql_mutations.py
+++ b/worker_voucher/gql_mutations.py
@@ -8,6 +8,7 @@ from core import datetime
 from core.gql.gql_mutations.base_mutation import BaseMutation
 from core.models import MutationLog
 from core.schema import OpenIMISMutation
+from graphql import GraphQLError
 from insuree.apps import InsureeConfig
 from insuree.gql_mutations import CreateInsureeMutation, CreateInsureeInputType
 from insuree.models import Insuree
@@ -274,7 +275,13 @@ class AcquireUnassignedVouchersMutation(BaseMutation):
 
         validate_result = validate_acquire_unassigned_vouchers(user, economic_unit_code, count)
         if not validate_result.get("success", False):
-            return validate_result
+            error_message = validate_result["error"]["message"]
+            error_extensions = validate_result["error"].get("extensions", {})
+
+            return GraphQLError(
+                message=error_message,
+                extensions=error_extensions
+            )
 
         policyholder_id = validate_result.get("data").get("policyholder").id
         voucher_ids = []

--- a/worker_voucher/schema.py
+++ b/worker_voucher/schema.py
@@ -11,6 +11,7 @@ from django.contrib.auth.models import AnonymousUser
 from core.gql.export_mixin import ExportableQueryMixin
 from core.schema import OrderedDjangoFilterConnectionField
 from core.utils import append_validity_filter, filter_validity
+from graphql import GraphQLError
 from insuree.apps import InsureeConfig
 from insuree.gql_queries import InsureeGQLType
 from insuree.models import Insuree
@@ -207,7 +208,12 @@ class Query(ExportableQueryMixin, graphene.ObjectType):
             raise AttributeError("worker_voucher.validation.unassigned_voucher_disabled")
         validation_result = validate_assign_vouchers(info.context.user, economic_unit_code, workers, date_ranges)
         if not validation_result.get("success", False):
-            raise AttributeError(validation_result.get("error", _("Unknown Error")))
+            error = validation_result.get("error", _("Unknown Error"))
+            extensions = validation_result.get("extensions", {})
+            raise GraphQLError(
+                message=error,
+                extensions=extensions
+            )
 
         validation_summary = validation_result.get("data")
         validation_summary.pop("policyholder")

--- a/worker_voucher/services.py
+++ b/worker_voucher/services.py
@@ -119,10 +119,10 @@ def validate_acquire_unassigned_vouchers(user: User, eu_code: str, count: Union[
         count = int(count)
         if count < 1:
             return {"success": False,
-                    "error": _("acquirement.validation.count_greater_than_zero"), }
+                    "error": _("workerVoucher.acquirement.validation.count_greater_than_zero"), }
         if count > WorkerVoucherConfig.max_generic_vouchers:
             return {"success": False,
-                    "error": _("acquirement.validation.max_voucher_count_exceeded"), }
+                    "error": _("workerVoucher.acquirement.validation.max_voucher_count_exceeded"), }
         return {
             "success": True,
             "data": {
@@ -203,7 +203,7 @@ def _check_ph(user: User, eu_code: str):
             economic_unit_user_filter(user, economic_unit_code=eu_code)
         )
     except PolicyHolder.DoesNotExist:
-        raise VoucherException("acquirement.validation.economic_unit_not_exists")
+        raise VoucherException("workerVoucher.acquirement.validation.economic_unit_not_exists")
 
 
 def _check_insurees(workers: List[str], eu_code: str, user: User):
@@ -222,7 +222,7 @@ def _check_insurees(workers: List[str], eu_code: str, user: User):
         else:
             insurees.add(ins)
     if not insurees:
-        raise VoucherException("acquirement.validation.no_valid_workers")
+        raise VoucherException("workerVoucher.acquirement.validation.no_valid_workers")
     return insurees
 
 
@@ -230,7 +230,7 @@ def _check_voucher_limit(insuree, user, policyholder, year, count=1):
     voucher_counts = get_worker_yearly_voucher_count_counts(insuree, user, year)
 
     if voucher_counts.get(policyholder.code, 0) + count > WorkerVoucherConfig.yearly_worker_voucher_limit:
-        raise VoucherException("acquirement.validation.yearly_voucher_limit_reached")
+        raise VoucherException("workerVoucher.acquirement.validation.yearly_voucher_limit_reached")
 
 
 def _check_dates(date_ranges: List[Dict]):
@@ -240,7 +240,7 @@ def _check_dates(date_ranges: List[Dict]):
         start_date, end_date = (datetime.date.from_ad_date(date_range.get("start_date")),
                                 datetime.date.from_ad_date(date_range.get("end_date")))
         if start_date < datetime.date.today():
-            raise VoucherException("acquirement.validation.date_in_past")
+            raise VoucherException("workerVoucher.acquirement.validation.date_in_past")
         if start_date > end_date:
             raise VoucherException(_(f"Start date {start_date} is after end date {end_date}"))
 
@@ -254,7 +254,7 @@ def _check_dates(date_ranges: List[Dict]):
             else:
                 dates.add(date)
     if not dates:
-        raise VoucherException("acquirement.validation.no_valid_dates")
+        raise VoucherException("workerVoucher.acquirement.validation.no_valid_dates")
     return dates
 
 def _get_voucher_expiry_date(start_date: datetime):
@@ -266,7 +266,7 @@ def _get_voucher_expiry_date(start_date: datetime):
         expiry_period = WorkerVoucherConfig.voucher_expiry_period
         expiry_date = datetime.datetime.today() + datetime.datetimedelta(**expiry_period)
     else:
-        raise VoucherException("acquirement.validation.invalid_expiry_type")
+        raise VoucherException("workerVoucher.acquirement.validation.invalid_expiry_type")
 
     return expiry_date
 
@@ -284,7 +284,7 @@ def check_existing_active_vouchers(ph, insurees, dates):
             is_deleted=False,
             **date_filter
     ).exists():
-        raise VoucherException("acquirement.validation.existing_active_vouchers")
+        raise VoucherException("workerVoucher.acquirement.validation.existing_active_vouchers")
 
 
 def _check_unassigned_vouchers(ph, dates, count):
@@ -298,7 +298,7 @@ def _check_unassigned_vouchers(ph, dates, count):
         status=WorkerVoucher.Status.UNASSIGNED,
         is_deleted=False).order_by('expiry_date')[:count]
     if unassigned_vouchers.count() < count:
-        raise VoucherException("acquirement.validation.not_enough_unassigned_vouchers")
+        raise VoucherException("workerVoucher.acquirement.validation.not_enough_unassigned_vouchers")
     return unassigned_vouchers
 
 
@@ -616,7 +616,7 @@ class GroupOfWorkerService(BaseService):
                     group = GroupOfWorker.objects.get(id=group_id)
                     if group.name != obj_data['name']:
                         if GroupOfWorker.objects.filter(name=obj_data['name'], is_deleted=False).count() > 0:
-                            raise VoucherException("worker_voucher.validation.group_name_already_exists")
+                            raise VoucherException("workerVoucher.worker_voucher.validation.group_name_already_exists")
                         [setattr(group, k, v) for k, v in obj_data.items()]
                         group.save(user=self.user)
                     if insurees is not None:
@@ -630,7 +630,7 @@ class GroupOfWorkerService(BaseService):
                             worker_group.save(user=self.user)
                 else:
                     if GroupOfWorker.objects.filter(name=obj_data['name'], is_deleted=False).count() > 0:
-                        raise ValidationError(_("This name for group already exists."))
+                        raise ValidationError("workerVoucher.worker_voucher.validation.group_name_already_exists")
                     group = GroupOfWorker(**obj_data)
                     group.save(user=self.user)
                     if insurees:

--- a/worker_voucher/services.py
+++ b/worker_voucher/services.py
@@ -173,10 +173,8 @@ def validate_acquire_assigned_vouchers(user: User, eu_code: str, workers: List[s
     except VoucherException as e:
         return {
             "success": False,
-            "error": {
-                "message": e.message,
-                "extensions": e.extensions
-            }
+            "error": e.message,
+            "extensions": e.extensions
         }
 
 
@@ -210,10 +208,8 @@ def validate_assign_vouchers(user: User, eu_code: str, workers: List[str], date_
     except VoucherException as e:
         return {
             "success": False,
-            "error": {
-                "message": e.message,
-                "extensions": e.extensions
-            }
+            "error": e.message,
+            "extensions": e.extensions
         }
 
 def _check_ph(user: User, eu_code: str):

--- a/worker_voucher/services.py
+++ b/worker_voucher/services.py
@@ -284,7 +284,7 @@ def check_existing_active_vouchers(ph, insurees, dates):
             is_deleted=False,
             **date_filter
     ).exists():
-        raise VoucherException(_("One or more workers have assigned vouchers in specified ranges"))
+        raise VoucherException("acquirement.validation.existing_active_vouchers")
 
 
 def _check_unassigned_vouchers(ph, dates, count):
@@ -298,7 +298,7 @@ def _check_unassigned_vouchers(ph, dates, count):
         status=WorkerVoucher.Status.UNASSIGNED,
         is_deleted=False).order_by('expiry_date')[:count]
     if unassigned_vouchers.count() < count:
-        raise VoucherException(_(f"Not enough unassigned vouchers"))
+        raise VoucherException("acquirement.validation.not_enough_unassigned_vouchers")
     return unassigned_vouchers
 
 

--- a/worker_voucher/services.py
+++ b/worker_voucher/services.py
@@ -22,6 +22,7 @@ from core.services.utils import (
     output_result_success
 )
 from core.signals import register_service_signal
+from graphql import GraphQLError
 from insuree.models import Insuree
 from insuree.gql_mutations import update_or_create_insuree
 from invoice.models import Bill
@@ -44,7 +45,14 @@ logger = logging.getLogger(__name__)
 
 
 class VoucherException(Exception):
-    pass
+    def __init__(self, message, extensions=None):
+        if isinstance(message, dict):
+            self.message = message.get("message", "Unknown error")
+            self.extensions = message.get("extensions", {})
+        else:
+            self.message = message
+            self.extensions = extensions or {}
+        super().__init__(self.message)
 
 
 class WorkerVoucherService(BaseService):
@@ -163,7 +171,10 @@ def validate_acquire_assigned_vouchers(user: User, eu_code: str, workers: List[s
             }
         }
     except VoucherException as e:
-        return {"success": False, "error": str(e)}
+        raise GraphQLError(
+            message=e.message,
+            extensions=e.extensions
+        )
 
 
 def validate_assign_vouchers(user: User, eu_code: str, workers: List[str], date_ranges: List[Dict]):
@@ -194,8 +205,10 @@ def validate_assign_vouchers(user: User, eu_code: str, workers: List[str], date_
             }
         }
     except VoucherException as e:
-        return {"success": False, "error": str(e)}
-
+        raise GraphQLError(
+            message=e.message,
+            extensions=e.extensions
+        )
 
 def _check_ph(user: User, eu_code: str):
     try:
@@ -216,15 +229,19 @@ def _check_insurees(workers: List[str], eu_code: str, user: User):
                 validity_to__isnull=True,
             )
         except Insuree.DoesNotExist:
-            raise VoucherException({
-                "message": "workerVoucher.validation.worker_not_exists",
-                "params": {"code": code}
-            })
+            raise VoucherException(
+                message="workerVoucher.validation.worker_not_exists",
+                extensions={
+                    "params": {"code": code}
+                }
+            )
         if ins in insurees:
-            raise VoucherException({
-                "message": "workerVoucher.validation.worker_duplicated",
-                "params": {"code": code}
-            })
+            raise VoucherException(
+                message= "workerVoucher.validation.worker_duplicated",
+                extensions={
+                    "params": {"code": code}
+                }
+            )
         else:
             insurees.add(ins)
     if not insurees:
@@ -246,33 +263,29 @@ def _check_dates(date_ranges: List[Dict]):
         start_date, end_date = (datetime.date.from_ad_date(date_range.get("start_date")),
                                 datetime.date.from_ad_date(date_range.get("end_date")))
         if start_date < datetime.date.today():
-            raise VoucherException({
-                "message": "workerVoucher.validation.start_date_in_past",
-                "params": {
-                    "start_date": start_date,
-                }})
+            raise VoucherException(
+                message="workerVoucher.validation.start_date_in_past",
+                extensions={"start_date": str(start_date)}
+            )
         if start_date > end_date:
-            raise VoucherException({
-                "message": "workerVoucher.validation.start_date_after_end_date",
-                "params": {
-                    "start_date": start_date,
-                    "end_date": end_date
-                }
-            })
+            raise VoucherException(
+                message="workerVoucher.validation.start_date_after_end_date",
+                extensions={"start_date": str(start_date), "end_date": str(end_date)}
+            )
 
         day_count = (end_date - start_date).days + 1
         for date in (start_date + datetime.datetimedelta(days=n) for n in
                      range(day_count)):
             if date in dates:
-                VoucherException({
-                    "message": "workerVoucher.validation.date_in_more_than_one_range",
-                    "date": date
-                })
+                raise VoucherException(
+                    message="workerVoucher.validation.date_in_more_than_one_range",
+                    extensions={"date": str(date)}
+                )
             if date > max_date:
-                VoucherException({
-                    "message": "workerVoucher.validation.date_after_voucher_expiry_date",
-                    "date": date
-                })
+                raise VoucherException(
+                    message="workerVoucher.validation.date_after_voucher_expiry_date",
+                    extensions={"date": str(date)}
+                )
             else:
                 dates.add(date)
     if not dates:

--- a/worker_voucher/services.py
+++ b/worker_voucher/services.py
@@ -119,10 +119,10 @@ def validate_acquire_unassigned_vouchers(user: User, eu_code: str, count: Union[
         count = int(count)
         if count < 1:
             return {"success": False,
-                    "error": _("workerVoucher.acquirement.validation.count_greater_than_zero"), }
+                    "error": _("workerVoucher.validation.count_greater_than_zero"), }
         if count > WorkerVoucherConfig.max_generic_vouchers:
             return {"success": False,
-                    "error": _("workerVoucher.acquirement.validation.max_voucher_count_exceeded"), }
+                    "error": _("workerVoucher.validation.max_voucher_count_exceeded"), }
         return {
             "success": True,
             "data": {
@@ -203,7 +203,7 @@ def _check_ph(user: User, eu_code: str):
             economic_unit_user_filter(user, economic_unit_code=eu_code)
         )
     except PolicyHolder.DoesNotExist:
-        raise VoucherException("workerVoucher.acquirement.validation.economic_unit_not_exists")
+        raise VoucherException("workerVoucher.validation.economic_unit_not_exists")
 
 
 def _check_insurees(workers: List[str], eu_code: str, user: User):
@@ -217,18 +217,18 @@ def _check_insurees(workers: List[str], eu_code: str, user: User):
             )
         except Insuree.DoesNotExist:
             raise VoucherException({
-                "message": "workerVoucher.acquirement.validation.worker_not_exists",
+                "message": "workerVoucher.validation.worker_not_exists",
                 "params": {"code": code}
             })
         if ins in insurees:
             raise VoucherException({
-                "message": "workerVoucher.acquirement.validation.worker_duplicated",
+                "message": "workerVoucher.validation.worker_duplicated",
                 "params": {"code": code}
             })
         else:
             insurees.add(ins)
     if not insurees:
-        raise VoucherException("workerVoucher.acquirement.validation.no_valid_workers")
+        raise VoucherException("workerVoucher.validation.no_valid_workers")
     return insurees
 
 
@@ -236,7 +236,7 @@ def _check_voucher_limit(insuree, user, policyholder, year, count=1):
     voucher_counts = get_worker_yearly_voucher_count_counts(insuree, user, year)
 
     if voucher_counts.get(policyholder.code, 0) + count > WorkerVoucherConfig.yearly_worker_voucher_limit:
-        raise VoucherException("workerVoucher.acquirement.validation.yearly_voucher_limit_reached")
+        raise VoucherException("workerVoucher.validation.yearly_voucher_limit_reached")
 
 
 def _check_dates(date_ranges: List[Dict]):
@@ -247,13 +247,13 @@ def _check_dates(date_ranges: List[Dict]):
                                 datetime.date.from_ad_date(date_range.get("end_date")))
         if start_date < datetime.date.today():
             raise VoucherException({
-                "message": "workerVoucher.acquirement.validation.start_date_in_past",
+                "message": "workerVoucher.validation.start_date_in_past",
                 "params": {
                     "start_date": start_date,
                 }})
         if start_date > end_date:
             raise VoucherException({
-                "message": "workerVoucher.acquirement.validation.start_date_after_end_date",
+                "message": "workerVoucher.validation.start_date_after_end_date",
                 "params": {
                     "start_date": start_date,
                     "end_date": end_date
@@ -265,18 +265,18 @@ def _check_dates(date_ranges: List[Dict]):
                      range(day_count)):
             if date in dates:
                 VoucherException({
-                    "message": "workerVoucher.acquirement.validation.date_in_more_than_one_range",
+                    "message": "workerVoucher.validation.date_in_more_than_one_range",
                     "date": date
                 })
             if date > max_date:
                 VoucherException({
-                    "message": "workerVoucher.acquirement.validation.date_after_voucher_expiry_date",
+                    "message": "workerVoucher.validation.date_after_voucher_expiry_date",
                     "date": date
                 })
             else:
                 dates.add(date)
     if not dates:
-        raise VoucherException("workerVoucher.acquirement.validation.validation.no_valid_dates")
+        raise VoucherException("workerVoucher.validation.validation.no_valid_dates")
     return dates
 
 def _get_voucher_expiry_date(start_date: datetime):
@@ -288,7 +288,7 @@ def _get_voucher_expiry_date(start_date: datetime):
         expiry_period = WorkerVoucherConfig.voucher_expiry_period
         expiry_date = datetime.datetime.today() + datetime.datetimedelta(**expiry_period)
     else:
-        raise VoucherException("workerVoucher.acquirement.validation.invalid_expiry_type")
+        raise VoucherException("workerVoucher.validation.invalid_expiry_type")
 
     return expiry_date
 
@@ -306,7 +306,7 @@ def check_existing_active_vouchers(ph, insurees, dates):
             is_deleted=False,
             **date_filter
     ).exists():
-        raise VoucherException("workerVoucher.acquirement.validation.existing_active_vouchers")
+        raise VoucherException("workerVoucher.validation.existing_active_vouchers")
 
 
 def _check_unassigned_vouchers(ph, dates, count):
@@ -320,7 +320,7 @@ def _check_unassigned_vouchers(ph, dates, count):
         status=WorkerVoucher.Status.UNASSIGNED,
         is_deleted=False).order_by('expiry_date')[:count]
     if unassigned_vouchers.count() < count:
-        raise VoucherException("workerVoucher.acquirement.validation.not_enough_unassigned_vouchers")
+        raise VoucherException("workerVoucher.validation.not_enough_unassigned_vouchers")
     return unassigned_vouchers
 
 
@@ -638,7 +638,7 @@ class GroupOfWorkerService(BaseService):
                     group = GroupOfWorker.objects.get(id=group_id)
                     if group.name != obj_data['name']:
                         if GroupOfWorker.objects.filter(name=obj_data['name'], is_deleted=False).count() > 0:
-                            raise VoucherException("workerVoucher.worker_voucher.validation.group_name_already_exists")
+                            raise VoucherException("workerVoucher.validation.group_name_already_exists")
                         [setattr(group, k, v) for k, v in obj_data.items()]
                         group.save(user=self.user)
                     if insurees is not None:

--- a/worker_voucher/services.py
+++ b/worker_voucher/services.py
@@ -171,10 +171,13 @@ def validate_acquire_assigned_vouchers(user: User, eu_code: str, workers: List[s
             }
         }
     except VoucherException as e:
-        raise GraphQLError(
-            message=e.message,
-            extensions=e.extensions
-        )
+        return {
+            "success": False,
+            "error": {
+                "message": e.message,
+                "extensions": e.extensions
+            }
+        }
 
 
 def validate_assign_vouchers(user: User, eu_code: str, workers: List[str], date_ranges: List[Dict]):
@@ -205,10 +208,13 @@ def validate_assign_vouchers(user: User, eu_code: str, workers: List[str], date_
             }
         }
     except VoucherException as e:
-        raise GraphQLError(
-            message=e.message,
-            extensions=e.extensions
-        )
+        return {
+            "success": False,
+            "error": {
+                "message": e.message,
+                "extensions": e.extensions
+            }
+        }
 
 def _check_ph(user: User, eu_code: str):
     try:

--- a/worker_voucher/services.py
+++ b/worker_voucher/services.py
@@ -216,9 +216,15 @@ def _check_insurees(workers: List[str], eu_code: str, user: User):
                 validity_to__isnull=True,
             )
         except Insuree.DoesNotExist:
-            raise VoucherException(_(f"Worker {code} does not exists"))
+            raise VoucherException({
+                "message": "workerVoucher.acquirement.validation.worker_not_exists",
+                "params": {"code": code}
+            })
         if ins in insurees:
-            raise VoucherException(_(f"Duplicate worker: {code}"))
+            raise VoucherException({
+                "message": "workerVoucher.acquirement.validation.worker_duplicated",
+                "params": {"code": code}
+            })
         else:
             insurees.add(ins)
     if not insurees:
@@ -240,21 +246,37 @@ def _check_dates(date_ranges: List[Dict]):
         start_date, end_date = (datetime.date.from_ad_date(date_range.get("start_date")),
                                 datetime.date.from_ad_date(date_range.get("end_date")))
         if start_date < datetime.date.today():
-            raise VoucherException("workerVoucher.acquirement.validation.date_in_past")
+            raise VoucherException({
+                "message": "workerVoucher.acquirement.validation.start_date_in_past",
+                "params": {
+                    "start_date": start_date,
+                }})
         if start_date > end_date:
-            raise VoucherException(_(f"Start date {start_date} is after end date {end_date}"))
+            raise VoucherException({
+                "message": "workerVoucher.acquirement.validation.start_date_after_end_date",
+                "params": {
+                    "start_date": start_date,
+                    "end_date": end_date
+                }
+            })
 
         day_count = (end_date - start_date).days + 1
         for date in (start_date + datetime.datetimedelta(days=n) for n in
                      range(day_count)):
             if date in dates:
-                raise VoucherException(_(f"Date {date} in more than one range"))
+                VoucherException({
+                    "message": "workerVoucher.acquirement.validation.date_in_more_than_one_range",
+                    "date": date
+                })
             if date > max_date:
-                raise VoucherException(_(f"Date {date} after voucher expiry date"))
+                VoucherException({
+                    "message": "workerVoucher.acquirement.validation.date_after_voucher_expiry_date",
+                    "date": date
+                })
             else:
                 dates.add(date)
     if not dates:
-        raise VoucherException("workerVoucher.acquirement.validation.no_valid_dates")
+        raise VoucherException("workerVoucher.acquirement.validation.validation.no_valid_dates")
     return dates
 
 def _get_voucher_expiry_date(start_date: datetime):

--- a/worker_voucher/services.py
+++ b/worker_voucher/services.py
@@ -119,10 +119,10 @@ def validate_acquire_unassigned_vouchers(user: User, eu_code: str, count: Union[
         count = int(count)
         if count < 1:
             return {"success": False,
-                    "error": _("Count have to be greater than 0"), }
+                    "error": _("acquirement.validation.count_greater_than_zero"), }
         if count > WorkerVoucherConfig.max_generic_vouchers:
             return {"success": False,
-                    "error": _("Max voucher count exceeded"), }
+                    "error": _("acquirement.validation.max_voucher_count_exceeded"), }
         return {
             "success": True,
             "data": {
@@ -203,7 +203,7 @@ def _check_ph(user: User, eu_code: str):
             economic_unit_user_filter(user, economic_unit_code=eu_code)
         )
     except PolicyHolder.DoesNotExist:
-        raise VoucherException(_(f"Economic unit {eu_code} does not exists"))
+        raise VoucherException("acquirement.validation.economic_unit_not_exists")
 
 
 def _check_insurees(workers: List[str], eu_code: str, user: User):
@@ -222,7 +222,7 @@ def _check_insurees(workers: List[str], eu_code: str, user: User):
         else:
             insurees.add(ins)
     if not insurees:
-        raise VoucherException(_("No valid workers"))
+        raise VoucherException("acquirement.validation.no_valid_workers")
     return insurees
 
 
@@ -230,7 +230,7 @@ def _check_voucher_limit(insuree, user, policyholder, year, count=1):
     voucher_counts = get_worker_yearly_voucher_count_counts(insuree, user, year)
 
     if voucher_counts.get(policyholder.code, 0) + count > WorkerVoucherConfig.yearly_worker_voucher_limit:
-        raise VoucherException(_(f"Worker {insuree.chf_id} reached yearly voucher limit"))
+        raise VoucherException("acquirement.validation.yearly_voucher_limit_reached")
 
 
 def _check_dates(date_ranges: List[Dict]):
@@ -240,7 +240,7 @@ def _check_dates(date_ranges: List[Dict]):
         start_date, end_date = (datetime.date.from_ad_date(date_range.get("start_date")),
                                 datetime.date.from_ad_date(date_range.get("end_date")))
         if start_date < datetime.date.today():
-            raise VoucherException(_(f"Date {start_date} is in the past"))
+            raise VoucherException("acquirement.validation.date_in_past")
         if start_date > end_date:
             raise VoucherException(_(f"Start date {start_date} is after end date {end_date}"))
 
@@ -254,7 +254,7 @@ def _check_dates(date_ranges: List[Dict]):
             else:
                 dates.add(date)
     if not dates:
-        raise VoucherException(_(f"No valid dates"))
+        raise VoucherException("acquirement.validation.no_valid_dates")
     return dates
 
 def _get_voucher_expiry_date(start_date: datetime):
@@ -266,7 +266,7 @@ def _get_voucher_expiry_date(start_date: datetime):
         expiry_period = WorkerVoucherConfig.voucher_expiry_period
         expiry_date = datetime.datetime.today() + datetime.datetimedelta(**expiry_period)
     else:
-        raise VoucherException(_("Invalid voucher expiry type"))
+        raise VoucherException("acquirement.validation.invalid_expiry_type")
 
     return expiry_date
 
@@ -616,7 +616,7 @@ class GroupOfWorkerService(BaseService):
                     group = GroupOfWorker.objects.get(id=group_id)
                     if group.name != obj_data['name']:
                         if GroupOfWorker.objects.filter(name=obj_data['name'], is_deleted=False).count() > 0:
-                            raise ValidationError(_("This name for group already exists."))
+                            raise VoucherException("worker_voucher.validation.group_name_already_exists")
                         [setattr(group, k, v) for k, v in obj_data.items()]
                         group.save(user=self.user)
                     if insurees is not None:


### PR DESCRIPTION
Changes:
- backend validation error returns a key message that can be translated by FE

Example of new message error:
![Screenshot from 2024-11-06 16-29-56](https://github.com/user-attachments/assets/7e2e32de-0c38-4e15-a15f-4c857bdd4992)
